### PR TITLE
bethesda.net and mobilesyrup.com are not NSA related

### DIFF
--- a/HOSTS/Trackers/canvas fingerprinting pages.txt
+++ b/HOSTS/Trackers/canvas fingerprinting pages.txt
@@ -1439,7 +1439,6 @@
 0.0.0.0 betapet.se
 0.0.0.0 betches.com
 0.0.0.0 bethblog.com
-0.0.0.0 bethesda.net
 0.0.0.0 betterafter.net
 0.0.0.0 betterdecoratingbible.com
 0.0.0.0 betterhensandgardens.com
@@ -8177,7 +8176,6 @@
 0.0.0.0 mobilesreview.co.in
 0.0.0.0 mobilesringtones.com
 0.0.0.0 mobilestechguru.com
-0.0.0.0 mobilesyrup.com
 0.0.0.0 mobiletechbase.com
 0.0.0.0 mobiletechreview.com
 0.0.0.0 mobileunlockguide.com


### PR DESCRIPTION
Mobilesyrup: A Canadian news site that reviews tech and writes news articles.
Bethesda.net: A legit gaming company

![image](https://user-images.githubusercontent.com/59746332/77829740-6d883780-70fa-11ea-82bf-bdd3488c62a3.png)
![image](https://user-images.githubusercontent.com/59746332/77829501-e4bccc00-70f8-11ea-9f96-0c35a0abd076.png)